### PR TITLE
Wait for 60 minutes instead of default 30

### DIFF
--- a/cmd/kni-install/create.go
+++ b/cmd/kni-install/create.go
@@ -238,7 +238,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
 
 	discovery := client.Discovery()
 
-	apiTimeout := 30 * time.Minute
+	apiTimeout := 60 * time.Minute
 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()


### PR DESCRIPTION
On baremetal, servers take longer when rebooting so extending the default timeout